### PR TITLE
Fix: Topology.Instances.Real.Lemmas

### DIFF
--- a/GlimpseOfLean/Exercises/03Forall.lean
+++ b/GlimpseOfLean/Exercises/03Forall.lean
@@ -1,6 +1,6 @@
 import GlimpseOfLean.Library.Basic
 import Mathlib.Topology.Order.IntermediateValue
-import Mathlib.Topology.Instances.Real.Defs
+import Mathlib.Topology.Instances.Real.Lemmas
 
 open Function
 


### PR DESCRIPTION
Mathlib.Topology.Instances.Real.Defs triggers a build error now.
Changing to .Lemmas solves it (.Defs doesn't exist anymore, I suppose).