### PR TITLE
More explanations for `rw` and the focussing dot

### DIFF
--- a/GlimpseOfLean/Exercises/01Rewriting.lean
+++ b/GlimpseOfLean/Exercises/01Rewriting.lean
@@ -42,7 +42,7 @@ lemma that is used by the `ring` tactic when needed.
 Let us now see how to compute using assumptions relating the involved numbers.
 This uses the fundamental property of equality: if two
 mathematical objects A and B are equal then, in any statement involving A, one can replace A
-by B. This operation is called rewriting, and the Lean tactic for this is `rw`.
+by B. This operation is called rewriting, and the basic Lean tactic for this is `rw`.
 Carefully step through the proof below and try to understand what is happening.
 -/
 example (a b c d e : ℝ) (h : a = b + c) (h' : b = d - e) : a + e = d + c := by {
@@ -56,6 +56,9 @@ Note the `rw` tactic changes the current goal. After the first line of the above
 the new goal is `b + c + e = d + c`. So you can read this first proof step as saying:
 "I wanted to prove, `a + e = d + c` but, since assumption `h` tells me `a = b + c`,
 it suffices to prove `b + c + e = d + c`."
+
+The `rw` tactic needs to be told every rewrite step. Later on we will see more powerful tactics
+that can automate the tedious steps for you.
 
 One can actually do several rewritings in one command.
 -/

--- a/GlimpseOfLean/Exercises/02Iff.lean
+++ b/GlimpseOfLean/Exercises/02Iff.lean
@@ -158,8 +158,10 @@ In order to prove an equivalence one can use `rw` until the
 goal is the tautology `P ↔ P`, just as one can do with equalities.
 
 One can also separately prove the two implications using the `constructor` tactic.
-
-Here is an example.
+Below is an example.
+If you put your cursor after `constructor`, you will see two goals, one for each direction.
+Lean will keep track of the goals for you, making sure you solve all of them.
+The "focussing dot" `·` keeps the proof for each goal separate.
 -/
 
 example (a b : ℝ) : (a-b)*(a+b) = 0 ↔ a^2 = b^2 := by {

--- a/GlimpseOfLean/Solutions/01Rewriting.lean
+++ b/GlimpseOfLean/Solutions/01Rewriting.lean
@@ -44,7 +44,7 @@ lemma that is used by the `ring` tactic when needed.
 Let us now see how to compute using assumptions relating the involved numbers.
 This uses the fundamental property of equality: if two
 mathematical objects A and B are equal then, in any statement involving A, one can replace A
-by B. This operation is called rewriting, and the Lean tactic for this is `rw`.
+by B. This operation is called rewriting, and the basic Lean tactic for this is `rw`.
 Carefully step through the proof below and try to understand what is happening.
 -/
 example (a b c d e : ℝ) (h : a = b + c) (h' : b = d - e) : a + e = d + c := by {
@@ -58,6 +58,9 @@ Note the `rw` tactic changes the current goal. After the first line of the above
 the new goal is `b + c + e = d + c`. So you can read this first proof step as saying:
 "I wanted to prove, `a + e = d + c` but, since assumption `h` tells me `a = b + c`,
 it suffices to prove `b + c + e = d + c`."
+
+The `rw` tactic needs to be told every rewrite step. Later on we will see more powerful tactics
+that can automate the tedious steps for you.
 
 One can actually do several rewritings in one command.
 -/

--- a/GlimpseOfLean/Solutions/02Iff.lean
+++ b/GlimpseOfLean/Solutions/02Iff.lean
@@ -181,8 +181,10 @@ In order to prove an equivalence one can use `rw` until the
 goal is the tautology `P ↔ P`, just as one can do with equalities.
 
 One can also separately prove the two implications using the `constructor` tactic.
-
-Here is an example.
+Below is an example.
+If you put your cursor after `constructor`, you will see two goals, one for each direction.
+Lean will keep track of the goals for you, making sure you solve all of them.
+The "focussing dot" `·` keeps the proof for each goal separate.
 -/
 
 example (a b : ℝ) : (a-b)*(a+b) = 0 ↔ a^2 = b^2 := by {


### PR DESCRIPTION
Discussed in the Zulip chat for LFTCM Bangalore. I am worried that starting with `rw` might give the suggestion that Lean proofs have to be very low level, so I added a line about more powerful tactics being available. Also, it seems we do not explain the focussing dot anywhere.