### PR TITLE
chore(Logic): rename valuations

### DIFF
--- a/GlimpseOfLean/Exercises/Topics/ClassicalPropositionalLogic.lean
+++ b/GlimpseOfLean/Exercises/Topics/ClassicalPropositionalLogic.lean
@@ -37,15 +37,15 @@ local infix:29 (priority := high) " ⇔ " => equiv
 /- Let's define truth w.r.t. a valuation, i.e. classical validity -/
 
 @[simp]
-def IsTrue (v : Variable → Prop) : Formula → Prop
+def IsTrue (φ : Variable → Prop) : Formula → Prop
   | ⊥      => False
-  | # P    => v P
-  | A || B => IsTrue v A ∨ IsTrue v B
-  | A && B => IsTrue v A ∧ IsTrue v B
-  | A ⇒ B => IsTrue v A → IsTrue v B
+  | # P    => φ P
+  | A || B => IsTrue φ A ∨ IsTrue φ B
+  | A && B => IsTrue φ A ∧ IsTrue φ B
+  | A ⇒ B => IsTrue φ A → IsTrue φ B
 
-def Satisfies (v : Variable → Prop) (Γ : Set Formula) : Prop := ∀ {A}, A ∈ Γ → IsTrue v A
-def Models (Γ : Set Formula) (A : Formula) : Prop := ∀ {v}, Satisfies v Γ → IsTrue v A
+def Satisfies (φ : Variable → Prop) (Γ : Set Formula) : Prop := ∀ {A}, A ∈ Γ → IsTrue φ A
+def Models (Γ : Set Formula) (A : Formula) : Prop := ∀ {φ}, Satisfies φ Γ → IsTrue φ A
 local infix:27 (priority := high) " ⊨ " => Models
 def Valid (A : Formula) : Prop := ∅ ⊨ A
 
@@ -54,13 +54,13 @@ def Valid (A : Formula) : Prop := ∅ ⊨ A
   The tactic `simp` will automatically simplify definitions tagged with `@[simp]` and rewrite
   using theorems tagged with `@[simp]`. -/
 
-variable {v : Variable → Prop} {A B : Formula}
-@[simp] lemma isTrue_neg : IsTrue v ~A ↔ ¬ IsTrue v A := by simp [neg]
+variable {φ : Variable → Prop} {A B : Formula}
+@[simp] lemma isTrue_neg : IsTrue φ ~A ↔ ¬ IsTrue φ A := by simp [neg]
 
-@[simp] lemma isTrue_top : IsTrue v ⊤ := by
+@[simp] lemma isTrue_top : IsTrue φ ⊤ := by
   sorry
 
-@[simp] lemma isTrue_equiv : IsTrue v (A ⇔ B) ↔ (IsTrue v A ↔ IsTrue v B) := by
+@[simp] lemma isTrue_equiv : IsTrue φ (A ⇔ B) ↔ (IsTrue φ A ↔ IsTrue φ B) := by
   sorry
 
 /- As an exercise, let's prove (using classical logic) the double negation elimination principle.
@@ -72,7 +72,7 @@ example : Valid (~~A ⇔ A) := by
 /- We will frequently need to add an element to a set. This is done using
 the `insert` function: `insert A Γ` means `Γ ∪ {A}`. -/
 
-@[simp] lemma satisfies_insert_iff : Satisfies v (insert A Γ) ↔ IsTrue v A ∧ Satisfies v Γ := by
+@[simp] lemma satisfies_insert_iff : Satisfies φ (insert A Γ) ↔ IsTrue φ A ∧ Satisfies φ Γ := by
   simp [Satisfies]
 
 /- Let's define provability w.r.t. classical logic. -/
@@ -199,4 +199,3 @@ theorem valid_of_provable (h : Provable A) : Valid A := by
 -/
 
 end ClassicalPropositionalLogic
-

--- a/GlimpseOfLean/Exercises/Topics/IntuitionisticPropositionalLogic.lean
+++ b/GlimpseOfLean/Exercises/Topics/IntuitionisticPropositionalLogic.lean
@@ -41,20 +41,20 @@ A valuation valued in Heyting algebra `H` is just a map from variables to `H`
 Let's define how to evaluate a valuation on propositional formulae. -/
 variable {H : Type*} [HeytingAlgebra H]
 @[simp]
-def eval (v : Variable → H) : Formula → H
+def eval (φ : Variable → H) : Formula → H
   | bot    => ⊥
-  | # P    => v P
-  | A || B => eval v A ⊔ eval v B
-  | A && B => eval v A ⊓ eval v B
-  | A ⇒ B => eval v A ⇨ eval v B
+  | # P    => φ P
+  | A || B => eval φ A ⊔ eval φ B
+  | A && B => eval φ A ⊓ eval φ B
+  | A ⇒ B => eval φ A ⇨ eval φ B
 
 /- We say that `A` is a consequence of `Γ` if for all valuations in any Heyting algebra, if
-  `eval v B` is above a certain element for all `B ∈ Γ` then `eval v A` is above this element.
+  `eval φ B` is above a certain element for all `B ∈ Γ` then `eval φ A` is above this element.
   Note that for finite sets `Γ` this corresponds exactly to
-  `Infimum { eval v B | B ∈ Γ } ≤ eval v A`.
+  `Infimum { eval φ B | B ∈ Γ } ≤ eval φ A`.
   This "yoneda'd" version of the definition of validity is very convenient to work with. -/
 def Models (Γ : Set Formula) (A : Formula) : Prop :=
-  ∀ {H : Type} [HeytingAlgebra H] {v : Variable → H} {c}, (∀ B ∈ Γ, c ≤ eval v B) → c ≤ eval v A
+  ∀ {H : Type} [HeytingAlgebra H] {φ : Variable → H} {c}, (∀ B ∈ Γ, c ≤ eval φ B) → c ≤ eval φ A
 
 local infix:27 (priority := high) " ⊨ " => Models
 def Valid (A : Formula) : Prop := ∅ ⊨ A
@@ -64,14 +64,14 @@ def Valid (A : Formula) : Prop := ∅ ⊨ A
   The tactic `simp` will automatically simplify definitions tagged with `@[simp]` and rewrite
   using theorems tagged with `@[simp]`. -/
 
-variable {v : Variable → H} {A B : Formula}
-@[simp] lemma eval_neg : eval v ~A = (eval v A)ᶜ := by simp [neg]
+variable {φ : Variable → H} {A B : Formula}
+@[simp] lemma eval_neg : eval φ ~A = (eval φ A)ᶜ := by simp [neg]
 
-@[simp] lemma eval_top : eval v top = ⊤ := by
+@[simp] lemma eval_top : eval φ top = ⊤ := by
   sorry
 
 @[simp]
-lemma isTrue_equiv : eval v (A ⇔ B) = (eval v A ⇨ eval v B) ⊓ (eval v B ⇨ eval v A) := by
+lemma isTrue_equiv : eval φ (A ⇔ B) = (eval φ A ⇨ eval φ B) ⊓ (eval φ B ⇨ eval φ A) := by
   sorry
 
 /- As an exercise, let's prove the following proposition, which holds in intuitionistic logic. -/
@@ -175,4 +175,3 @@ theorem valid_of_provable (h : Provable A) : Valid A := by
 -/
 
 end IntuitionisticPropositionalLogic
-

--- a/GlimpseOfLean/Solutions/Topics/ClassicalPropositionalLogic.lean
+++ b/GlimpseOfLean/Solutions/Topics/ClassicalPropositionalLogic.lean
@@ -37,15 +37,15 @@ local infix:29 (priority := high) " ⇔ " => equiv
 /- Let's define truth w.r.t. a valuation, i.e. classical validity -/
 
 @[simp]
-def IsTrue (v : Variable → Prop) : Formula → Prop
+def IsTrue (φ : Variable → Prop) : Formula → Prop
   | ⊥      => False
-  | # P    => v P
-  | A || B => IsTrue v A ∨ IsTrue v B
-  | A && B => IsTrue v A ∧ IsTrue v B
-  | A ⇒ B => IsTrue v A → IsTrue v B
+  | # P    => φ P
+  | A || B => IsTrue φ A ∨ IsTrue φ B
+  | A && B => IsTrue φ A ∧ IsTrue φ B
+  | A ⇒ B => IsTrue φ A → IsTrue φ B
 
-def Satisfies (v : Variable → Prop) (Γ : Set Formula) : Prop := ∀ {A}, A ∈ Γ → IsTrue v A
-def Models (Γ : Set Formula) (A : Formula) : Prop := ∀ {v}, Satisfies v Γ → IsTrue v A
+def Satisfies (φ : Variable → Prop) (Γ : Set Formula) : Prop := ∀ {A}, A ∈ Γ → IsTrue φ A
+def Models (Γ : Set Formula) (A : Formula) : Prop := ∀ {φ}, Satisfies φ Γ → IsTrue φ A
 local infix:27 (priority := high) " ⊨ " => Models
 def Valid (A : Formula) : Prop := ∅ ⊨ A
 
@@ -54,15 +54,15 @@ def Valid (A : Formula) : Prop := ∅ ⊨ A
   The tactic `simp` will automatically simplify definitions tagged with `@[simp]` and rewrite
   using theorems tagged with `@[simp]`. -/
 
-variable {v : Variable → Prop} {A B : Formula}
-@[simp] lemma isTrue_neg : IsTrue v ~A ↔ ¬ IsTrue v A := by simp [neg]
+variable {φ : Variable → Prop} {A B : Formula}
+@[simp] lemma isTrue_neg : IsTrue φ ~A ↔ ¬ IsTrue φ A := by simp [neg]
 
-@[simp] lemma isTrue_top : IsTrue v ⊤ := by
+@[simp] lemma isTrue_top : IsTrue φ ⊤ := by
   -- sorry
   simp [top]
   -- sorry
 
-@[simp] lemma isTrue_equiv : IsTrue v (A ⇔ B) ↔ (IsTrue v A ↔ IsTrue v B) := by
+@[simp] lemma isTrue_equiv : IsTrue φ (A ⇔ B) ↔ (IsTrue φ A ↔ IsTrue φ B) := by
   -- sorry
   simp [equiv]
   tauto
@@ -73,14 +73,14 @@ variable {v : Variable → Prop} {A B : Formula}
 
 example : Valid (~~A ⇔ A) := by
   -- sorry
-  intros v _
+  intros φ _
   simp
   -- sorry
 
 /- We will frequently need to add an element to a set. This is done using
 the `insert` function: `insert A Γ` means `Γ ∪ {A}`. -/
 
-@[simp] lemma satisfies_insert_iff : Satisfies v (insert A Γ) ↔ IsTrue v A ∧ Satisfies v Γ := by
+@[simp] lemma satisfies_insert_iff : Satisfies φ (insert A Γ) ↔ IsTrue φ A ∧ Satisfies φ Γ := by
   simp [Satisfies]
 
 /- Let's define provability w.r.t. classical logic. -/
@@ -245,17 +245,17 @@ lemma Provable.mp (h1 : Provable (A ⇒ B)) (h2 : Γ ⊢ A) : Γ ⊢ B := by
   tactic `cases h` if `h` is a disjunction to do a case distinction. -/
 theorem soundness_theorem (h : Γ ⊢ A) : Γ ⊨ A := by
   -- sorry
-  induction h <;> intros v hv
+  induction h <;> intros φ hφ
   solve_by_elim
   case impI ih => intro hA; apply ih; simp [*]
-  case impE ih₁ ih₂ => exact ih₁ hv (ih₂ hv)
-  case botC ih => by_contra hA; apply ih (satisfies_insert_iff.mpr ⟨by exact hA, hv⟩)
-  case andI ih₁ ih₂ => exact ⟨ih₁ hv, ih₂ hv⟩
-  case andE1 ih => exact (ih hv).1
-  case andE2 ih => exact (ih hv).2
-  case orI1 ih => exact .inl (ih hv)
-  case orI2 ih => exact .inr (ih hv)
-  case orE ih₁ ih₂ ih₃ => refine (ih₁ hv).elim (fun hA => ih₂ ?_) (fun hB => ih₃ ?_) <;> simp [*]
+  case impE ih₁ ih₂ => exact ih₁ hφ (ih₂ hφ)
+  case botC ih => by_contra hA; apply ih (satisfies_insert_iff.mpr ⟨by exact hA, hφ⟩)
+  case andI ih₁ ih₂ => exact ⟨ih₁ hφ, ih₂ hφ⟩
+  case andE1 ih => exact (ih hφ).1
+  case andE2 ih => exact (ih hφ).2
+  case orI1 ih => exact .inl (ih hφ)
+  case orI2 ih => exact .inr (ih hφ)
+  case orE ih₁ ih₂ ih₃ => refine (ih₁ hφ).elim (fun hA => ih₂ ?_) (fun hB => ih₃ ?_) <;> simp [*]
   -- sorry
 
 theorem valid_of_provable (h : Provable A) : Valid A := by

--- a/GlimpseOfLean/Solutions/Topics/IntuitionisticPropositionalLogic.lean
+++ b/GlimpseOfLean/Solutions/Topics/IntuitionisticPropositionalLogic.lean
@@ -41,20 +41,20 @@ A valuation valued in Heyting algebra `H` is just a map from variables to `H`
 Let's define how to evaluate a valuation on propositional formulae. -/
 variable {H : Type*} [HeytingAlgebra H]
 @[simp]
-def eval (v : Variable → H) : Formula → H
+def eval (φ : Variable → H) : Formula → H
   | bot    => ⊥
-  | # P    => v P
-  | A || B => eval v A ⊔ eval v B
-  | A && B => eval v A ⊓ eval v B
-  | A ⇒ B => eval v A ⇨ eval v B
+  | # P    => φ P
+  | A || B => eval φ A ⊔ eval φ B
+  | A && B => eval φ A ⊓ eval φ B
+  | A ⇒ B => eval φ A ⇨ eval φ B
 
 /- We say that `A` is a consequence of `Γ` if for all valuations in any Heyting algebra, if
-  `eval v B` is above a certain element for all `B ∈ Γ` then `eval v A` is above this element.
+  `eval φ B` is above a certain element for all `B ∈ Γ` then `eval φ A` is above this element.
   Note that for finite sets `Γ` this corresponds exactly to
-  `Infimum { eval v B | B ∈ Γ } ≤ eval v A`.
+  `Infimum { eval φ B | B ∈ Γ } ≤ eval φ A`.
   This "yoneda'd" version of the definition of validity is very convenient to work with. -/
 def Models (Γ : Set Formula) (A : Formula) : Prop :=
-  ∀ {H : Type} [HeytingAlgebra H] {v : Variable → H} {c}, (∀ B ∈ Γ, c ≤ eval v B) → c ≤ eval v A
+  ∀ {H : Type} [HeytingAlgebra H] {φ : Variable → H} {c}, (∀ B ∈ Γ, c ≤ eval φ B) → c ≤ eval φ A
 
 local infix:27 (priority := high) " ⊨ " => Models
 def Valid (A : Formula) : Prop := ∅ ⊨ A
@@ -64,16 +64,16 @@ def Valid (A : Formula) : Prop := ∅ ⊨ A
   The tactic `simp` will automatically simplify definitions tagged with `@[simp]` and rewrite
   using theorems tagged with `@[simp]`. -/
 
-variable {v : Variable → H} {A B : Formula}
-@[simp] lemma eval_neg : eval v ~A = (eval v A)ᶜ := by simp [neg]
+variable {φ : Variable → H} {A B : Formula}
+@[simp] lemma eval_neg : eval φ ~A = (eval φ A)ᶜ := by simp [neg]
 
-@[simp] lemma eval_top : eval v top = ⊤ := by
+@[simp] lemma eval_top : eval φ top = ⊤ := by
   -- sorry
   simp [top]
   -- sorry
 
 @[simp]
-lemma isTrue_equiv : eval v (A ⇔ B) = (eval v A ⇨ eval v B) ⊓ (eval v B ⇨ eval v A) := by
+lemma isTrue_equiv : eval φ (A ⇔ B) = (eval φ A ⇨ eval φ B) ⊓ (eval φ B ⇨ eval φ A) := by
   -- sorry
   simp [equiv]
   -- sorry
@@ -208,7 +208,7 @@ lemma Provable.mp (h1 : Provable (A ⇒ B)) (h2 : Γ ⊢ A) : Γ ⊢ B := by
 set_option maxHeartbeats 0 in
 theorem soundness_theorem (h : Γ ⊢ A) : Γ ⊨ A := by
   -- sorry
-  induction h <;> intros H hH v c hv
+  induction h <;> intros H hH φ c hφ
   solve_by_elim
   case impI ih =>
     simp
@@ -216,38 +216,38 @@ theorem soundness_theorem (h : Γ ⊢ A) : Γ ⊨ A := by
     simp
     intros B hB
     -- apply?
-    exact inf_le_of_left_le (hv B hB)
+    exact inf_le_of_left_le (hφ B hB)
   case impE ih₁ ih₂ =>
-    specialize ih₁ hv
+    specialize ih₁ hφ
     simp at ih₁
-    rwa [inf_eq_left.mpr (ih₂ hv)] at ih₁
-  case andI ih₁ ih₂ => simp [ih₁ hv, ih₂ hv]
+    rwa [inf_eq_left.mpr (ih₂ hφ)] at ih₁
+  case andI ih₁ ih₂ => simp [ih₁ hφ, ih₂ hφ]
   case andE1 ih =>
-    specialize ih hv
+    specialize ih hφ
     simp at ih
     exact ih.1
   case andE2 ih =>
-    specialize ih hv
+    specialize ih hφ
     simp at ih
     exact ih.2
   case orI1 ih =>
     simp
-    exact le_trans (ih hv) le_sup_left
+    exact le_trans (ih hφ) le_sup_left
   case orI2 ih =>
     simp
-    exact le_trans (ih hv) le_sup_right
+    exact le_trans (ih hφ) le_sup_right
   case orE Γ A B C _h1 _h2 _h3 ih₁ ih₂ ih₃ =>
-    specialize ih₁ hv
-    have h2v : ∀ D ∈ insert A Γ, c ⊓ eval v A ≤ eval v D := by
-      simp; intros D hD; exact inf_le_of_left_le (hv D hD) -- apply? found this
-    have h3v : ∀ D ∈ insert B Γ, c ⊓ eval v B ≤ eval v D := by
-      simp; intros D hD; exact inf_le_of_left_le (hv D hD) -- apply? found this
+    specialize ih₁ hφ
+    have h2φ : ∀ D ∈ insert A Γ, c ⊓ eval φ A ≤ eval φ D := by
+      simp; intros D hD; exact inf_le_of_left_le (hφ D hD) -- apply? found this
+    have h3φ : ∀ D ∈ insert B Γ, c ⊓ eval φ B ≤ eval φ D := by
+      simp; intros D hD; exact inf_le_of_left_le (hφ D hD) -- apply? found this
     simp at ih₁
     rw [← inf_eq_left.mpr ih₁, inf_sup_left]
-    rw [← sup_idem (a := eval v C)]
-    exact sup_le_sup (ih₂ h2v) (ih₃ h3v)
+    rw [← sup_idem (a := eval φ C)]
+    exact sup_le_sup (ih₂ h2φ) (ih₃ h3φ)
   case botE ih =>
-    specialize ih hv
+    specialize ih hφ
     simp at ih
     simp [ih]
   -- sorry


### PR DESCRIPTION
These files are about logic, and the `v` variable name is easily misread as the logical disjunction symbol. To minimise the chance of confusion, we rename `v` to `φ` everywhere.